### PR TITLE
Remove ENGINE_ROOT to fix migrations problem

### DIFF
--- a/lib/spree/seo.rb
+++ b/lib/spree/seo.rb
@@ -1,11 +1,9 @@
 require "spree/seo/version"
 require "spree/seo/engine"
 
-ENGINE_ROOT = File.expand_path('../..', __FILE__)
 ENGINE_PATH = File.expand_path('../../lib/spree/seo/engine', __FILE__)
 
 require 'rails/all'
-require 'rails/engine/commands'
 require 'spree_core'
 require 'spree_api'
 


### PR DESCRIPTION
Problem: 
`rails g migration x` generates migrations inside gem's db directory. 
Removing those 2 lines fixes the problem 